### PR TITLE
Fix data race in GC frame recording between signal handler and postponed job

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,4 +24,11 @@ else
   end
 end
 
-task default: %i(compile test)
+task :compile_for_test do
+  ENV['STACKPROF_TESTING'] = '1'
+  Rake::Task[:clean].invoke
+  Rake::Task[:compile].invoke
+end
+
+task test: :compile_for_test
+task default: :test

--- a/ext/stackprof/extconf.rb
+++ b/ext/stackprof/extconf.rb
@@ -5,6 +5,10 @@ if RUBY_ENGINE == 'truffleruby'
   return
 end
 
+if ENV['STACKPROF_TESTING']
+  $CFLAGS << ' -DSTACKPROF_TESTING'
+end
+
 if (have_func('rb_postponed_job_preregister') ||
     have_func('rb_postponed_job_register_one')) &&
    have_func('rb_profile_frames') &&

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -544,7 +544,7 @@ st_numtable_increment(st_table *table, st_data_t key, size_t increment)
 }
 
 void
-stackprof_record_sample_for_stack(int num, uint64_t sample_timestamp, int64_t timestamp_delta)
+stackprof_record_sample_for_stack(int num, VALUE *frames_buffer, int *lines_buffer, uint64_t sample_timestamp, int64_t timestamp_delta)
 {
     int i, n;
     VALUE prev_frame = Qnil;
@@ -578,8 +578,8 @@ stackprof_record_sample_for_stack(int num, uint64_t sample_timestamp, int64_t ti
 	     * in the raw buffer are stored in the opposite direction of stacks
 	     * in the frames buffer that came from Ruby. */
 	    for (i = num-1, n = 0; i >= 0; i--, n++) {
-		VALUE frame = _stackprof.frames_buffer[i];
-		int line = _stackprof.lines_buffer[i];
+		VALUE frame = frames_buffer[i];
+		int line = lines_buffer[i];
 
 		// Encode the line in to the upper 16 bits.
 		uint64_t key = ((uint64_t)line << 48) | (uint64_t)frame;
@@ -601,8 +601,8 @@ stackprof_record_sample_for_stack(int num, uint64_t sample_timestamp, int64_t ti
 	    _stackprof.raw_sample_index = _stackprof.raw_samples_len;
 	    _stackprof.raw_samples[_stackprof.raw_samples_len++] = (VALUE)num;
 	    for (i = num-1; i >= 0; i--) {
-		VALUE frame = _stackprof.frames_buffer[i];
-		int line = _stackprof.lines_buffer[i];
+		VALUE frame = frames_buffer[i];
+		int line = lines_buffer[i];
 
 		// Encode the line in to the upper 16 bits.
 		uint64_t key = ((uint64_t)line << 48) | (uint64_t)frame;
@@ -633,8 +633,8 @@ stackprof_record_sample_for_stack(int num, uint64_t sample_timestamp, int64_t ti
     }
 
     for (i = 0; i < num; i++) {
-	int line = _stackprof.lines_buffer[i];
-	VALUE frame = _stackprof.frames_buffer[i];
+	int line = lines_buffer[i];
+	VALUE frame = frames_buffer[i];
 	frame_data_t *frame_data = sample_for(frame);
 
 	if (frame_data->seen_at_sample_number != _stackprof.overall_samples) {
@@ -717,11 +717,15 @@ stackprof_record_gc_samples(void)
     for (i = 0; i < _stackprof.unrecorded_gc_samples; i++) {
 	int64_t timestamp_delta = i == 0 ? delta_to_first_unrecorded_gc_sample : NUM2LONG(_stackprof.interval);
 
+	/* Use local arrays for GC frames to avoid a data race with the
+	 * signal handler, which can overwrite _stackprof.frames_buffer
+	 * via stackprof_buffer_sample/rb_profile_frames at any time. */
+	VALUE gc_frames[2];
+	int gc_lines[2] = {0, 0};
+
       if (_stackprof.unrecorded_gc_marking_samples) {
-        _stackprof.frames_buffer[0] = FAKE_FRAME_MARK;
-        _stackprof.lines_buffer[0] = 0;
-        _stackprof.frames_buffer[1] = FAKE_FRAME_GC;
-        _stackprof.lines_buffer[1] = 0;
+        gc_frames[0] = FAKE_FRAME_MARK;
+        gc_frames[1] = FAKE_FRAME_GC;
         _stackprof.unrecorded_gc_marking_samples--;
 
 #ifdef STACKPROF_TESTING
@@ -731,12 +735,10 @@ stackprof_record_gc_samples(void)
             _stackprof.buffer_count = 0;
         }
 #endif
-        stackprof_record_sample_for_stack(2, start_timestamp, timestamp_delta);
+        stackprof_record_sample_for_stack(2, gc_frames, gc_lines, start_timestamp, timestamp_delta);
       } else if (_stackprof.unrecorded_gc_sweeping_samples) {
-        _stackprof.frames_buffer[0] = FAKE_FRAME_SWEEP;
-        _stackprof.lines_buffer[0] = 0;
-        _stackprof.frames_buffer[1] = FAKE_FRAME_GC;
-        _stackprof.lines_buffer[1] = 0;
+        gc_frames[0] = FAKE_FRAME_SWEEP;
+        gc_frames[1] = FAKE_FRAME_GC;
 
         _stackprof.unrecorded_gc_sweeping_samples--;
 
@@ -747,10 +749,9 @@ stackprof_record_gc_samples(void)
             _stackprof.buffer_count = 0;
         }
 #endif
-        stackprof_record_sample_for_stack(2, start_timestamp, timestamp_delta);
+        stackprof_record_sample_for_stack(2, gc_frames, gc_lines, start_timestamp, timestamp_delta);
       } else {
-        _stackprof.frames_buffer[0] = FAKE_FRAME_GC;
-        _stackprof.lines_buffer[0] = 0;
+        gc_frames[0] = FAKE_FRAME_GC;
 
 #ifdef STACKPROF_TESTING
         if (stackprof_record_gc_samples_hook) {
@@ -759,7 +760,7 @@ stackprof_record_gc_samples(void)
             _stackprof.buffer_count = 0;
         }
 #endif
-        stackprof_record_sample_for_stack(1, start_timestamp, timestamp_delta);
+        stackprof_record_sample_for_stack(1, gc_frames, gc_lines, start_timestamp, timestamp_delta);
       }
     }
     _stackprof.during_gc += _stackprof.unrecorded_gc_samples;
@@ -772,7 +773,7 @@ stackprof_record_gc_samples(void)
 static void
 stackprof_record_buffer(void)
 {
-    stackprof_record_sample_for_stack(_stackprof.buffer_count, _stackprof.buffer_time.timestamp_usec, _stackprof.buffer_time.delta_usec);
+    stackprof_record_sample_for_stack(_stackprof.buffer_count, _stackprof.frames_buffer, _stackprof.lines_buffer, _stackprof.buffer_time.timestamp_usec, _stackprof.buffer_time.delta_usec);
 
     // reset the buffer
     _stackprof.buffer_count = 0;

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -45,6 +45,13 @@ static const char *fake_frame_cstrs[] = {
 static int stackprof_use_postponed_job = 1;
 static int ruby_vm_running = 0;
 
+#ifdef STACKPROF_TESTING
+/* Hook called between setting up GC frames and recording them.
+ * A test extension can set this to inject a stackprof_buffer_sample() call,
+ * reproducing the signal handler race that overwrites frames_buffer. */
+void (*stackprof_record_gc_samples_hook)(void) = NULL;
+#endif
+
 #define TOTAL_FAKE_FRAMES (sizeof(fake_frame_cstrs) / sizeof(char *))
 
 #ifdef _POSIX_MONOTONIC_CLOCK
@@ -717,6 +724,13 @@ stackprof_record_gc_samples(void)
         _stackprof.lines_buffer[1] = 0;
         _stackprof.unrecorded_gc_marking_samples--;
 
+#ifdef STACKPROF_TESTING
+        if (stackprof_record_gc_samples_hook) {
+            _stackprof.buffer_count = 0;
+            stackprof_record_gc_samples_hook();
+            _stackprof.buffer_count = 0;
+        }
+#endif
         stackprof_record_sample_for_stack(2, start_timestamp, timestamp_delta);
       } else if (_stackprof.unrecorded_gc_sweeping_samples) {
         _stackprof.frames_buffer[0] = FAKE_FRAME_SWEEP;
@@ -726,10 +740,25 @@ stackprof_record_gc_samples(void)
 
         _stackprof.unrecorded_gc_sweeping_samples--;
 
+#ifdef STACKPROF_TESTING
+        if (stackprof_record_gc_samples_hook) {
+            _stackprof.buffer_count = 0;
+            stackprof_record_gc_samples_hook();
+            _stackprof.buffer_count = 0;
+        }
+#endif
         stackprof_record_sample_for_stack(2, start_timestamp, timestamp_delta);
       } else {
         _stackprof.frames_buffer[0] = FAKE_FRAME_GC;
         _stackprof.lines_buffer[0] = 0;
+
+#ifdef STACKPROF_TESTING
+        if (stackprof_record_gc_samples_hook) {
+            _stackprof.buffer_count = 0;
+            stackprof_record_gc_samples_hook();
+            _stackprof.buffer_count = 0;
+        }
+#endif
         stackprof_record_sample_for_stack(1, start_timestamp, timestamp_delta);
       }
     }

--- a/test/ext/extconf.rb
+++ b/test/ext/extconf.rb
@@ -1,0 +1,2 @@
+require "mkmf"
+create_makefile("stackprof_test_helper")

--- a/test/ext/stackprof_test_helper.c
+++ b/test/ext/stackprof_test_helper.c
@@ -1,0 +1,40 @@
+#include <ruby/ruby.h>
+
+/*
+ * These symbols are provided by the stackprof shared object, which is
+ * already loaded when this test helper is required.
+ */
+extern void stackprof_buffer_sample(void);
+extern void (*stackprof_record_gc_samples_hook)(void);
+
+static void
+simulate_signal_handler(void)
+{
+    /* This is exactly what the signal handler does when it fires outside
+     * of GC with stackprof_use_postponed_job == 0: it calls
+     * stackprof_buffer_sample(), which invokes rb_profile_frames() and
+     * overwrites _stackprof.frames_buffer with the current call stack. */
+    stackprof_buffer_sample();
+}
+
+static VALUE
+install_hook(VALUE self)
+{
+    stackprof_record_gc_samples_hook = simulate_signal_handler;
+    return Qnil;
+}
+
+static VALUE
+remove_hook(VALUE self)
+{
+    stackprof_record_gc_samples_hook = NULL;
+    return Qnil;
+}
+
+void
+Init_stackprof_test_helper(void)
+{
+    VALUE mod = rb_define_module("StackProfTestHelper");
+    rb_define_singleton_method(mod, "install_gc_race_hook", install_hook, 0);
+    rb_define_singleton_method(mod, "remove_gc_race_hook", remove_hook, 0);
+}

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -265,6 +265,61 @@ class StackProfTest < Minitest::Test
     assert_operator profile[:missed_samples], :<=, 25
   end
 
+  # Regression test for a data race where the signal handler calls
+  # stackprof_buffer_sample() -> rb_profile_frames(), overwriting the shared
+  # _stackprof.frames_buffer while stackprof_record_gc_samples is using it
+  # to record GC fake frames.
+  #
+  # A separate test C extension (stackprof_test_helper) installs a hook via
+  # the stackprof_record_gc_samples_hook function pointer that calls
+  # stackprof_buffer_sample() inside stackprof_record_gc_samples, right
+  # after GC frames are set up but before stackprof_record_sample_for_stack
+  # processes them - exactly reproducing what happens when a signal arrives
+  # at that point. On unfixed code, this overwrites the GC frames in the
+  # shared buffer with real stack frames, so the GC frame IDs end up in raw
+  # but never in the frames hash. On fixed code, GC frames use stack-local
+  # arrays immune to the overwrite.
+  def test_gc_frames_not_clobbered_by_signal_handler
+    build_and_load_test_helper
+    StackProfTestHelper.install_gc_race_hook
+
+    profile = StackProf.run(interval: 100, raw: true) do
+      5.times do
+        GC.start
+      end
+    end
+
+    raw = profile[:raw]
+    frames = profile[:frames]
+
+    gc_frame = frames.values.find{ |f| f[:name] == "(garbage collection)" }
+    assert gc_frame, "expected (garbage collection) frame in frames hash but it was missing"
+
+    # Verify every frame referenced in raw exists in frames
+    missing_frames = []
+    if raw && raw.size > 0
+      i = 0
+      while i < raw.size
+        num = raw[i]
+        i += 1
+        num.times do
+          frame_id = raw[i]
+          unless frames.key?(frame_id)
+            missing_frames << frame_id
+          end
+          i += 1
+        end
+        i += 1 # skip count
+      end
+    end
+
+    assert_empty missing_frames,
+      "raw sample data references frame IDs not present in frames hash: #{missing_frames.uniq.inspect}. " \
+      "This indicates the signal handler overwrote frames_buffer during GC recording."
+  ensure
+    StackProfTestHelper.remove_gc_race_hook if defined?(StackProfTestHelper)
+  end
+
   def test_out
     tmpfile = Tempfile.new('stackprof-out')
     ret = StackProf.run(mode: :custom, out: tmpfile) do
@@ -324,5 +379,20 @@ class StackProfTest < Minitest::Test
   ensure
     r.close
     w.close
+  end
+
+  def build_and_load_test_helper
+    return if defined?(StackProfTestHelper)
+
+    ext_dir = File.expand_path("ext", __dir__)
+    unless File.exist?(File.join(ext_dir, "Makefile"))
+      system(RbConfig.ruby, "extconf.rb", chdir: ext_dir, exception: true,
+             out: File::NULL, err: File::NULL)
+    end
+    system("make", "-C", ext_dir, "-j", exception: true,
+           out: File::NULL, err: File::NULL)
+    require "#{ext_dir}/stackprof_test_helper"
+  rescue LoadError => e
+    skip "test helper not available (compile with STACKPROF_TESTING=1): #{e.message}"
   end
 end unless RUBY_ENGINE == 'truffleruby'


### PR DESCRIPTION
## Problem

Production stackprof profiles occasionally produce `raw` sample data referencing frame IDs that don't exist in the `frames` hash. Downstream consumers (e.g. stackprof2pprof converters) fail with errors like:

```
frame not found 1
```

From a production profile (`test.json`), the `raw` array contains a GC stack referencing frames `1` and `5`:

```json
"raw": [..., 2, 1, 5, 1, ...]
         // ↑num ↑frames ↑count
         // Stack of 2 frames: [1, 5], seen 1 time
```

Frame `5` (`(sweeping)`) is present in the `frames` hash:
```json
"5": {
    "name": "(sweeping)",
    "file": "",
    "total_samples": 1,
    "samples": 1
}
```

But frame `1` (`(garbage collection)`) is **missing entirely** from `frames`, despite being referenced in `raw`. The profile has `gc_samples: 1`, confirming GC was recorded — but the frame entry was lost.

## Root cause

`stackprof_record_gc_samples()` writes fake GC frame values (`FAKE_FRAME_GC`, `FAKE_FRAME_SWEEP`, etc.) directly into the **shared** `_stackprof.frames_buffer`, then calls `stackprof_record_sample_for_stack()` which reads from that same buffer. On Ruby >= 3.0 with `stackprof_use_postponed_job == 0`, the signal handler calls `stackprof_buffer_sample()` directly, which invokes `rb_profile_frames()` — overwriting `_stackprof.frames_buffer` with real stack frames.

If a signal arrives while `stackprof_record_gc_samples` (running as a postponed job) is between writing GC frames to the buffer and having `stackprof_record_sample_for_stack` process them, the GC frame data is clobbered. The raw samples may have already been serialized (loop 1 in `stackprof_record_sample_for_stack`), but the frames hash table (loop 2) reads the now-overwritten buffer and never creates entries for the fake GC frames.

## Commit structure

### Commit 1: `3cbef91` — Regression test (cherry-pick this to `master` to see the failure)

This occurs during a rare race condition, but I wanted to reproduce it with a test, so I added test infrastructure to deterministically reproduce the race:

- **`stackprof_record_gc_samples_hook`** — a function pointer in `stackprof.c`, guarded by `#ifdef STACKPROF_TESTING`, called between GC frame setup and recording. Compiles out of production builds entirely.
- **`ext/stackprof/extconf.rb`** — reads `STACKPROF_TESTING` env var to add `-DSTACKPROF_TESTING` to `$CFLAGS`.
- **`Rakefile`** — `compile_for_test` task sets the env var, cleans, and recompiles. The `test` task depends on it.
- **`test/ext/stackprof_test_helper.c`** — a separate C extension that sets the hook to call `stackprof_buffer_sample()`, the exact function the signal handler calls in production. This overwrites `_stackprof.frames_buffer` via `rb_profile_frames()` at precisely the point where the race occurs.
- **`test/test_stackprof.rb`** — `test_gc_frames_not_clobbered_by_signal_handler` installs the hook, runs profiling with `GC.start`, then verifies that every frame ID in `raw` has a corresponding entry in `frames`. The test auto-compiles the helper extension on first use and skips gracefully if `STACKPROF_TESTING` wasn't set.

To reproduce the failure on master:
```sh
git cherry-pick 3cbef91
STACKPROF_TESTING=1 rake clean compile
ruby -Ilib -Itest test/test_stackprof.rb --name test_gc_frames_not_clobbered_by_signal_handler
# => Failure: expected (garbage collection) frame in frames hash but it was missing
```

Note that this adds significant new infrastructure to stackprof and represents the majority of the changes in this PR. However:

- I think that we can reuse this pattern in the future, when we have gnarly bugs that only show up in rare situations and depend on race conditions, we can reuse this approach of:
  - Adding a hook function to this test .so 
  - Placing calls behind macro definitions to the stub function, so it only runs during testing, and only for the specific test where the hook is applied
- The test code, although it does modify stackprof.c, does **not** run (or even exist) in production because it is behind a test-only macro
  - Yes, this makes readability a bit worse, but i think it is worth the tradeoff to be able to have the regression tests
  - I decided this was better cosmetically than exposing these hooks through to ruby, and keeps these test hooks as private as possible

### Commit 2: `13c2974` — The fix

Changes `stackprof_record_sample_for_stack()` to take explicit `VALUE *frames_buffer` and `int *lines_buffer` parameters instead of reading from the shared global.

- **`stackprof_record_gc_samples()`** now uses **stack-local arrays** (`gc_frames[2]`, `gc_lines[2]`) for GC frames and passes them to `stackprof_record_sample_for_stack()`. The signal handler can overwrite `_stackprof.frames_buffer` all it wants — the local arrays are unaffected.
- **`stackprof_record_buffer()`** passes the shared `_stackprof.frames_buffer` explicitly. This is safe because `buffer_count > 0` prevents `stackprof_buffer_sample()` from re-entering while a buffer is pending.

The fix is a minimal 1-file, 22-insertion/21-deletion change to `ext/stackprof/stackprof.c`.